### PR TITLE
Side bar nav wasn't looking good in my window size

### DIFF
--- a/app/views/links/_form.html.erb
+++ b/app/views/links/_form.html.erb
@@ -14,14 +14,14 @@
   <div class="control-group">
     <div class="input-background">
       <i class="icon-font"></i>
-      <%= f.text_field :title, placeholder: "Title" %>
+      <%= f.text_field :title, placeholder: "Title", :class => "span2" %>
     </div>
   </div>
 
   <div class="control-group">
     <div class="input-background">
       <i class="icon-link"></i>
-      <%= f.text_field :url, placeholder: "URL" %>
+      <%= f.text_field :url, placeholder: "URL" , :class => "span2" %>
     </div>
   </div>
 


### PR DESCRIPTION
Not sure what my window size is, but it's about what full screen would be on 11" MBA. Slightly less than full screen on 13" macbook results in the below picture:

![broken sidenav](http://f.cl.ly/items/433E0n443q3a0O1I1C0f/Screen%20Shot%202012-11-13%20at%207.03.41%20PM.png)

This pull request fixes it. I checked locally, turns it into roughly:

![updated sidenav](http://f.cl.ly/items/1c212y3l2x1M3c3A0q0i/Screen%20Shot%202012-11-13%20at%207.05.56%20PM.png)

It adjusts better as screen shrinks as well.

Cheers! :+1: 
